### PR TITLE
Replace pygments with rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 name: Flex
 markdown: redcarpet
-pygments: true
+highlighter: rouge


### PR DESCRIPTION
GitHub didn't like pygments, and was replacing it with rouge anyway, so
better to use rouge in the first place.